### PR TITLE
used httparty gem directly instead of unmaintained httmultiparty gem

### DIFF
--- a/lib/soundcloud.rb
+++ b/lib/soundcloud.rb
@@ -1,5 +1,5 @@
 require 'hashie'
-require 'httmultiparty'
+require 'httparty'
 require 'uri'
 
 require 'soundcloud/array_response_wrapper'

--- a/lib/soundcloud/client.rb
+++ b/lib/soundcloud/client.rb
@@ -2,7 +2,7 @@ require 'soundcloud/version'
 
 module SoundCloud
   class Client
-    include HTTMultiParty
+    include HTTParty
     USER_AGENT            = "SoundCloud Ruby Wrapper #{SoundCloud::VERSION}"
     CLIENT_ID_PARAM_NAME  = :client_id
     API_SUBHOST           = 'api'
@@ -134,7 +134,7 @@ module SoundCloud
       params.merge!(:client_id => client_id, :client_secret => client_secret)
 
       response = handle_response(false) {
-        self.class.post("https://#{api_host}#{TOKEN_PATH}", :query => params)
+        self.class.post("https://#{api_host}#{TOKEN_PATH}", :body => params)
       }
 
       @options.merge!(:access_token => response.access_token, :refresh_token => response.refresh_token)

--- a/lib/soundcloud/version.rb
+++ b/lib/soundcloud/version.rb
@@ -1,3 +1,3 @@
 module SoundCloud
-  VERSION = '0.3.4'
+  VERSION = '0.3.4.1'
 end

--- a/soundcloud.gemspec
+++ b/soundcloud.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.required_rubygems_version = '>= 1.3.5'
 
-  spec.add_dependency('httmultiparty', '~> 0.3.0')
+  spec.add_dependency('httparty', '>= 0.16.4')
   spec.add_dependency('hashie')
 
   spec.add_development_dependency('bundler', '~> 1.0')

--- a/spec/soundcloud_spec.rb
+++ b/spec/soundcloud_spec.rb
@@ -221,7 +221,7 @@ describe SoundCloud do
 
       it "calls authorize endpoint to exchange token and store them when refresh token is passed" do
         allow(subject.class).to receive(:post)
-        expect(SoundCloud::Client).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :query => {
+        expect(SoundCloud::Client).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :body => {
           :grant_type    => 'refresh_token',
           :refresh_token => 'refresh',
           :client_id     => 'client',
@@ -234,7 +234,7 @@ describe SoundCloud do
 
       it "calls authorize endpoint to exchange token and store them when credentials are passed" do
         subject
-        expect(SoundCloud::Client).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :query => {
+        expect(SoundCloud::Client).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :body => {
           :grant_type    => 'password',
           :username      => 'foo@bar.com',
           :password      => 'pass',
@@ -247,7 +247,7 @@ describe SoundCloud do
       end
 
       it "calls authorize endpoint to exchange token and store them when code and redirect_uri are passed" do
-        expect(subject.class).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :query => {
+        expect(subject.class).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :body => {
           :grant_type    => 'authorization_code',
           :redirect_uri  => 'http://somewhere.com/bla',
           :code          => 'pass',


### PR DESCRIPTION
## Remove HttMultiParty gem and use httparty directly

Removes HttpMultiparty gem in favour of httparty gem as the former is outdated 

## Type of change
Cleanup

## Related issues

Fix GLM-2464

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
