### PR TITLE
GLM-6475 - Security > Add gemlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-Gemfile.lock
 /coverage
 /pkg

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,63 @@
+PATH
+  remote: .
+  specs:
+    soundcloud (0.3.4.1)
+      hashie
+      httparty (>= 0.16.4)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    hashdiff (1.0.1)
+    hashie (5.0.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
+    mini_mime (1.1.2)
+    multi_xml (0.6.0)
+    public_suffix (5.0.1)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.1)
+  rake (>= 10.1)
+  rspec (>= 3)
+  simplecov (>= 0.7)
+  soundcloud!
+  webmock (>= 1.13)
+
+BUNDLED WITH
+   2.1.4

--- a/soundcloud.gemspec
+++ b/soundcloud.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('httparty', '>= 0.16.4')
   spec.add_dependency('hashie')
 
-  spec.add_development_dependency('bundler', '~> 1.0')
+  spec.add_development_dependency('bundler', '~> 2.1')
 
   spec.files        = Dir.glob("lib/**/*") + %w(LICENSE.md README.md)
   spec.require_path = 'lib'


### PR DESCRIPTION
Dependabot wants us to bump Bundler and add a Gemlock file. This patch does that. Details:
https://github.com/Crowd9/soundcloud-ruby/security/dependabot/4